### PR TITLE
leighklotz: add --execute / --no-execute to ask

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Alternatively, you can install it using pip:
 
 3. Run the command if you want to. If you're using `free-genie`, and you want to help improve the tool, you can provide feedback after you've run the command.
 
-   You can use `shell-genie ask --no-execute` to inhibit the "Run this command" question.
+   You can use `shell-genie ask --no-execute` to inhibit the "Run this command" question, like this:
 
    ```shell
    shell-genie ask --no-execute "list open files for process"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Alternatively, you can install it using pip:
 
 3. Run the command if you want to. If you're using `free-genie`, and you want to help improve the tool, you can provide feedback after you've run the command.
 
+   You can use `shell-genie ask --no-execute` to inhibit the "Run this command" question.
+
+   ```shell
+   shell-genie ask --no-execute "list open files for process"
+   ```
+   And you'll see an output similar to this:
+
+   ```shell
+   Command: lsof -p <process_id>
+   ```
+
 ### Using an alias
 
 If you find that writing `shell-genie ask` is too verbose, you can create an alias for the tool:

--- a/shell_genie/main.py
+++ b/shell_genie/main.py
@@ -92,6 +92,7 @@ def init():
 def ask(
     wish: str = typer.Argument(..., help="What do you want to do?"),
     explain: bool = False,
+    execute: bool = None
 ):
     app_dir = typer.get_app_dir(APP_NAME)
     config_path = Path(app_dir) / "config.json"
@@ -115,7 +116,8 @@ def ask(
         pyperclip.copy(command)
         print("[green]Command copied to clipboard.[/green]")
     else:
-        execute = Confirm.ask("Do you want to run the command?")
+        if execute is None:
+            execute = Confirm.ask("Do you want to run the command?")
         if execute:
             subprocess.run(command, shell=True)
             feedback = False


### PR DESCRIPTION
Example usage:

```
$ shell-genie ask --execute "echo test"
Command: echo test
test
$ shell-genie ask --explain "echo test"
Command: echo "test"
Description: The "echo" command is used to display a line of text on the terminal. In this case, the command "echo test" will simply print the word "test" on the terminal. The double quotes around the word "test" are optional in this case, as there are no special characters or spaces that need to be preserved. This command should work on Ubuntu 22.04.3 LTS using the bash shell. Do you want to run the command? [y/n]: n
$ shell-genie ask --no-execute --explain "echo test" Command: echo "test"
Description: The "echo" command is used to display a line of text on the terminal. In this case, the command "echo test" will simply print the word "test" on the terminal. The double quotes around the word "test" are optional in this case, as there are no special characters or spaces that need to be preserved. This command should work on Ubuntu 22.04.3 LTS using the bash shell. $ shell-genie ask --no-execute "echo test"
Command: echo test
$ shell-genie ask "echo test"
Command: echo test
Do you want to run the command? [y/n]: n
$
```